### PR TITLE
Bugfix opening multiple experiments

### DIFF
--- a/papylio/file.py
+++ b/papylio/file.py
@@ -196,7 +196,7 @@ class File:
     @return_none_when_executed_by_pycharm
     def absoluteFilePath(self):
         """Return the absolute path to the file."""
-        return self.relativeFilePath.absolute()
+        return self.experiment.main_path.joinpath(self.relativeFilePath)
 
     @property
     @return_none_when_executed_by_pycharm


### PR DESCRIPTION
If the files have comparable names, then File.absoluteFilePath of the first experiment gives reference to the file in the second experiment.

The cause is that Path.absolute() gives the absolute filepath with respect to the working directory, which goes wrong when opening multiple experiments in one session.